### PR TITLE
Update linked_list_test.rb

### DIFF
--- a/test/linked_list_test.rb
+++ b/test/linked_list_test.rb
@@ -97,7 +97,7 @@ describe LinkedList do
             expect(@list.length).must_equal 3
         end
         
-        it "will return `nil` for `getLast` if the list is empty" do
+        it "will return `nil` for `get_last` if the list is empty" do
             # Act-Assert
             expect(@list.get_last).must_be_nil
         end

--- a/test/linked_list_test.rb
+++ b/test/linked_list_test.rb
@@ -96,6 +96,11 @@ describe LinkedList do
             expect(@list.get_last).must_equal 4
             expect(@list.length).must_equal 3
         end
+        
+        it "will return `nil` for `getLast` if the list is empty" do
+            # Act-Assert
+            expect(@list.get_last).must_be_nil
+        end
     end
 
     describe 'get_at_index' do


### PR DESCRIPTION
Currently if you call @list.get_last on an empty list, you get an error, such as "NoMethodError: undefined method `next' for nil:NilClass". This assumes the implemented method uses .next to move the pointer to the end of the list.